### PR TITLE
Skip if password is too short

### DIFF
--- a/pyethrecover.py
+++ b/pyethrecover.py
@@ -180,6 +180,8 @@ def generate_all(el, tr):
         yield tr
 
 def attempt(w, pw):
+    if len(pw) < 10:
+        return ""
     try:
         print (pw)
         raise PasswordFoundException(


### PR DESCRIPTION
Skip attempting to decrypt wallet if permuted password length is less than 10. Password length was minimum 10 characters.
