### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It's essentially a stripped-down version of [pyethsaletool](https://github.com/e
 to be used to generate passwords. The multiprocessing library `joblib` is used to test out passwords using
 all the cores on your machine. 
 
-This tool is compatible with both Python 2 and Python 3. It depends on the following libraries
+This tool is compatible with both Python 2. It depends on the following libraries
     
     joblib
     bitcoin


### PR DESCRIPTION
`file` is not compatible with Python3, see https://stackoverflow.com/questions/16736833/python-nameerror-name-file-is-not-defined

And is used here: https://github.com/burjorjee/pyethrecover/blob/master/pyethrecover.py#L216