### PR TITLE
Fix Python 3 exception incompatibility

### DIFF
--- a/pyethrecover.py
+++ b/pyethrecover.py
@@ -131,13 +131,13 @@ class DecryptionException(Exception):
 def getseed(encseed, pw, ethaddr):
     try:
         seed = aes.decryptData(pw, binascii.unhexlify(encseed))
-    except Exception, e:
+    except Exception as e:
         raise DecryptionException("AES Decryption error. Bad password?")
     try:
         ethpriv = sha3(seed)
         eth_privtoaddr(ethpriv)
         assert eth_privtoaddr(ethpriv) == ethaddr
-    except Exception, e:
+    except Exception as e:
         # print ("eth_priv = %s" % eth_privtoaddr(ethpriv))
         # print ("ethadd = %s" % ethaddr)
         # traceback.print_exc()
@@ -165,7 +165,7 @@ def crack(wallet_filename, grammar):
     w = json.loads(t)
     try:
         Parallel(n_jobs=-1)(delayed(attempt)(w, pw) for pw in generate_all(grammar,''))
-    except Exception, e:
+    except Exception as e:
         traceback.print_exc()
         while True:
             sys.stdout.write('\a')
@@ -219,7 +219,7 @@ def __main__():
 
     try:
         Parallel(n_jobs=-1)(delayed(attempt)(w, pw) for pw in pwds)
-    except Exception, e:
+    except Exception as e:
         traceback.print_exc()
         while True:
             sys.stdout.write('\a')


### PR DESCRIPTION
The exception aliasing syntax of `except Exception, e:` is not supported in Python 3. Instead, the more modern `except Exception as e:` is preferable, and is backwards compatible with Python 2.